### PR TITLE
SAML: disable proxy when opening auth dialog

### DIFF
--- a/auth-dialog/main.c
+++ b/auth-dialog/main.c
@@ -745,11 +745,17 @@ static gboolean open_webview_idle(gpointer data)
 	// Create a browser instance
 	webView = WEBKIT_WEB_VIEW(webkit_web_view_new());
 
+	dont_use_proxy_for_auth = g_hash_table_lookup(ui_data->options,
+                                                      NM_OPENCONNECT_DONT_USE_PROXY_AUTHENTICATION);
+
 	dm = webkit_web_view_get_website_data_manager(webView);
 	if (dm) {
 		cm = webkit_website_data_manager_get_cookie_manager(dm);
-                // Ensure that proxies won't be used on auth dialog
-                webkit_website_data_manager_set_network_proxy_settings(dm, WEBKIT_NETWORK_PROXY_MODE_NO_PROXY, NULL);
+
+                if (dont_use_proxy_for_auth) {
+                        // Ensure that proxies won't be used on auth dialog
+                        webkit_website_data_manager_set_network_proxy_settings(dm, WEBKIT_NETWORK_PROXY_MODE_NO_PROXY, NULL);
+                }
         }
 	if (cm)
 		storage = g_string_new (g_get_user_data_dir());

--- a/auth-dialog/main.c
+++ b/auth-dialog/main.c
@@ -746,8 +746,11 @@ static gboolean open_webview_idle(gpointer data)
 	webView = WEBKIT_WEB_VIEW(webkit_web_view_new());
 
 	dm = webkit_web_view_get_website_data_manager(webView);
-	if (dm)
+	if (dm) {
 		cm = webkit_website_data_manager_get_cookie_manager(dm);
+                // Ensure that proxies won't be used on auth dialog
+                webkit_website_data_manager_set_network_proxy_settings(dm, WEBKIT_NETWORK_PROXY_MODE_NO_PROXY, NULL);
+        }
 	if (cm)
 		storage = g_string_new (g_get_user_data_dir());
 	if (storage)

--- a/properties/nm-openconnect-dialog.ui
+++ b/properties/nm-openconnect-dialog.ui
@@ -325,6 +325,23 @@
       </packing>
     </child>
     <child>
+      <object class="GtkCheckButton" id="dont_use_proxy_for_authentication">
+        <property name="visible">True</property>
+        <property name="can_focus">True</property>
+        <property name="label" translatable="yes">Don't use system proxy settings during authentication</property>
+        <property name="use_underline">True</property>
+        <property name="focus_on_click">True</property>
+        <property name="active">False</property>
+        <property name="inconsistent">False</property>
+        <property name="draw_indicator">True</property>
+      </object>
+      <packing>
+        <property name="left_attach">0</property>
+        <property name="top_attach">13</property>
+        <property name="width">2</property>
+      </packing>
+    </child>
+    <child>
       <object class="GtkLabel" id="token_label">
         <property name="visible">False</property>
         <property name="label" translatable="yes">Software Token Authentication</property>
@@ -344,7 +361,7 @@
       </object>
       <packing>
           <property name="left_attach">0</property>
-          <property name="top_attach">13</property>
+          <property name="top_attach">14</property>
           <property name="width">2</property>
       </packing>
     </child>
@@ -366,7 +383,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">14</property>
+        <property name="top_attach">15</property>
       </packing>
     </child>
     <child>
@@ -384,7 +401,7 @@
       </object>
       <packing>
         <property name="left_attach">1</property>
-        <property name="top_attach">14</property>
+        <property name="top_attach">15</property>
       </packing>
     </child>
     <child>
@@ -406,7 +423,7 @@
       </object>
       <packing>
         <property name="left_attach">0</property>
-        <property name="top_attach">15</property>
+        <property name="top_attach">16</property>
       </packing>
     </child>
     <child>

--- a/properties/nm-openconnect-editor-plugin.c
+++ b/properties/nm-openconnect-editor-plugin.c
@@ -264,6 +264,11 @@ import (NMVpnEditorPlugin *iface, const char *path, GError **error)
 	if (true)
 		nm_setting_vpn_add_data_item (s_vpn, NM_OPENCONNECT_KEY_PREVENT_INVALID_CERT, "yes");
 
+	/* Don't use system proxy settings during authentication */
+	bval = g_key_file_get_boolean (keyfile, "openconnect", "DontUseProxyAuth", NULL);
+	if (true)
+		nm_setting_vpn_add_data_item (s_vpn, NM_OPENCONNECT_DONT_USE_PROXY_AUTHENTICATION, "yes");
+
 	/* Soft token mode */
 	buf = g_key_file_get_string (keyfile, "openconnect", "StokenSource", NULL);
 	if (buf)
@@ -363,6 +368,10 @@ export (NMVpnEditorPlugin *iface,
 		pem_passphrase_fsid = TRUE;
 
 	value = nm_setting_vpn_get_data_item (s_vpn, NM_OPENCONNECT_KEY_PREVENT_INVALID_CERT);
+	if (value && !strcmp (value, "yes"))
+		prevent_invalid_cert = TRUE;
+
+	value = nm_setting_vpn_get_data_item (s_vpn, NM_OPENCONNECT_DONT_USE_PROXY_AUTHENTICATION);
 	if (value && !strcmp (value, "yes"))
 		prevent_invalid_cert = TRUE;
 

--- a/properties/nm-openconnect-editor.c
+++ b/properties/nm-openconnect-editor.c
@@ -364,7 +364,17 @@ init_editor_plugin (OpenconnectEditor *self, NMConnection *connection, GError **
 	}
 	g_signal_connect (G_OBJECT (widget), "toggled", G_CALLBACK (stuff_changed_cb), self);
 
-	widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "csd_button"));
+	widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "dont_use_proxy_for_authentication"));
+	g_return_val_if_fail (widget, FALSE);
+
+	if (s_vpn) {
+		value = nm_setting_vpn_get_data_item (s_vpn, NM_OPENCONNECT_DONT_USE_PROXY_AUTHENTICATION);
+		if (value && !strcmp(value, "yes"))
+			gtk_check_button_set_active (GTK_CHECK_BUTTON (widget), TRUE);
+	}
+	g_signal_connect (G_OBJECT (widget), "toggled", G_CALLBACK (stuff_changed_cb), self);
+
+        widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "csd_button"));
 	g_return_val_if_fail (widget, FALSE);
 
 	if (s_vpn) {
@@ -467,6 +477,10 @@ update_connection (NMVpnEditor *iface,
 	widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "prevent_invalid_cert_button"));
 	str = gtk_check_button_get_active (GTK_CHECK_BUTTON (widget))?"yes":"no";
 	nm_setting_vpn_add_data_item (s_vpn, NM_OPENCONNECT_KEY_PREVENT_INVALID_CERT, str);
+
+	widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "dont_use_proxy_for_authentication"));
+	str = gtk_check_button_get_active (GTK_CHECK_BUTTON (widget))?"yes":"no";
+	nm_setting_vpn_add_data_item (s_vpn, NM_OPENCONNECT_DONT_USE_PROXY_AUTHENTICATION, str);
 
 	widget = GTK_WIDGET (gtk_builder_get_object (priv->builder, "csd_button"));
 	str = gtk_check_button_get_active (GTK_CHECK_BUTTON (widget))?"yes":"no";

--- a/shared/nm-service-defines.h
+++ b/shared/nm-service-defines.h
@@ -43,6 +43,7 @@
 #define NM_OPENCONNECT_KEY_MTU "mtu"
 #define NM_OPENCONNECT_KEY_PEM_PASSPHRASE_FSID "pem_passphrase_fsid"
 #define NM_OPENCONNECT_KEY_PREVENT_INVALID_CERT "prevent_invalid_cert"
+#define NM_OPENCONNECT_DONT_USE_PROXY_AUTHENTICATION "no_proxy_auth"
 #define NM_OPENCONNECT_KEY_PROTOCOL "protocol"
 #define NM_OPENCONNECT_KEY_PROXY "proxy"
 #define NM_OPENCONNECT_KEY_CSD_ENABLE "enable_csd_trojan"

--- a/src/nm-openconnect-service.c
+++ b/src/nm-openconnect-service.c
@@ -88,6 +88,7 @@ static const ValidProperty valid_properties[] = {
 	{ NM_OPENCONNECT_KEY_MTU,         G_TYPE_STRING, 0, 0 },
 	{ NM_OPENCONNECT_KEY_PEM_PASSPHRASE_FSID, G_TYPE_BOOLEAN, 0, 0 },
 	{ NM_OPENCONNECT_KEY_PREVENT_INVALID_CERT, G_TYPE_BOOLEAN, 0, 0 },
+	{ NM_OPENCONNECT_DONT_USE_PROXY_AUTHENTICATION, G_TYPE_BOOLEAN, 0, 0 },
 	{ NM_OPENCONNECT_KEY_PROTOCOL,    G_TYPE_STRING, 0, 0 },
 	{ NM_OPENCONNECT_KEY_PROXY,       G_TYPE_STRING, 0, 0 },
 	{ NM_OPENCONNECT_KEY_CSD_ENABLE,  G_TYPE_BOOLEAN, 0, 0 },
@@ -603,7 +604,7 @@ real_need_secrets (NMVpnServicePlugin *plugin,
 	}
 
 	/* We just need the WebVPN cookie, and the final IP address of the gateway
-	   (after HTTP redirects, which do happen). All the certificate/SecurID 
+	   (after HTTP redirects, which do happen). All the certificate/SecurID
 	   nonsense can be handled for us, in the user's context, by auth-dialog */
 	if (!nm_setting_vpn_get_secret (s_vpn, NM_OPENCONNECT_KEY_GATEWAY)) {
 		*setting_name = NM_SETTING_VPN_SETTING_NAME;


### PR DESCRIPTION
The system environment may have proxy set, which is needed after connecting with the VPN. Using it for the actual VPN won't work, as it would try to connect to an internal proxy without success.

Ensure that no proxies will be used during SAML dialogs.

Caught this while trying to connect with Palo Alto Network GlobalConnect with SAML configured to login via Microsoft cloud.